### PR TITLE
feat: use RLIMIT_DATA instead of RLIMIT_AS

### DIFF
--- a/parent.py
+++ b/parent.py
@@ -198,7 +198,7 @@ def child(
 ):
     if memory:
         memory_bytes = memory * 1000
-        resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+        resource.setrlimit(resource.RLIMIT_DATA, (memory_bytes, memory_bytes))
 
     if stack:
         if stack > 0:


### PR DESCRIPTION
should be ok and some programs have problem with small address space eg. newest node needs more than 1G AS just to start up, while actually needing only ~600M DATA